### PR TITLE
Update play-services-wallet version to prevent build error

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -9,7 +9,7 @@ android {
 
 dependencies {
     compile 'com.braintreepayments.api:drop-in:3.+'
-    compile 'com.google.android.gms:play-services-wallet:+'
+    compile 'com.google.android.gms:play-services-wallet:15.0.1'
     compile 'io.card:android-sdk:5.5.1'
 }
 


### PR DESCRIPTION
Do this to prevent a build error when phonegap-plugin-push brings in play-services.